### PR TITLE
Add exception handling on sherpa failures

### DIFF
--- a/plot_pixel_values.py
+++ b/plot_pixel_values.py
@@ -94,6 +94,8 @@ def print_info_block(fits, last_dat):
     other_t_ccd = [-10, -5, 0, 5, 10]
     for pix_id in sorted(fits):
         fitinfo = fits[pix_id]
+        if fitinfo is None:
+            continue
         m = fitinfo['modpars']
         dc = dark_scale_model((m.scale.val, m.dark_t_ref.val), last_dat['TEMPCD'])
         ref_dc = dark_scale_model((m.scale.val, m.dark_t_ref.val), -19)
@@ -104,6 +106,8 @@ def print_info_block(fits, last_dat):
             dc_temp = dark_scale_model((m.scale.val, m.dark_t_ref.val), t_ccd)
             new_rec.append(dc_temp / ref_dc)
         mini_table.append(new_rec)
+    if not len(mini_table):
+        return
     colnames = ['PixId', 'Val', 'Val(-19)', 'Scale', 'DC(T)/DC(-19)']
     for t_ccd in other_t_ccd:
         colnames.append("DC({})/DC(-19)".format(str(int(t_ccd))))
@@ -201,12 +205,20 @@ while True:
                         ha='center', va='center',
                         color='lightgrey')
             t_ccd = dat['TEMPCD']
-            fit, modpars = fit_pix_values(t_ccd,
-                                          y,
-                                          id=i_col)
-            fits[y.name] = {'fit': fit,
-                            'modpars': modpars}
-            fitmod = ui.get_model_plot(i_col)
+            try:
+                fit, modpars = fit_pix_values(t_ccd,
+                                              y,
+                                              id=i_col)
+                fits[y.name] = {'fit': fit,
+                                'modpars': modpars}
+                fitmod = ui.get_model_plot(i_col)
+            except Exception as exception:
+                logger = logging.getLogger('sherpa')
+                logger.warn('Sherpa fit failed on {}'.format(y.name))
+                logger.warn(exception)
+                logger.warn('Continuing')
+                fits[y.name] = None
+                continue
             if len(ax.lines) > 1:
                 l1 = ax.lines[1]
                 l1.set_data(x, fitmod.y)


### PR DESCRIPTION
In case of sherpa fail fit, add exception handling to continue printing time/temperature and making plots.
