### PR TITLE
Val(-19) doesn't match my expectation

### DIFF
--- a/plot_pixel_values.py
+++ b/plot_pixel_values.py
@@ -100,20 +100,22 @@ def print_info_block(fits, last_dat):
         dc = dark_scale_model((m.scale.val, m.dark_t_ref.val), last_dat['TEMPCD'])
         ref_dc = dark_scale_model((m.scale.val, m.dark_t_ref.val), -19)
         scale_factor = ref_dc / dc
-        minus_19_val = last_dat[pix_id] * scale_factor
-        new_rec = [pix_id, last_dat[pix_id], minus_19_val, m.scale.val, dc / ref_dc]
+        rec_esec = last_dat[pix_id] * GAIN / last_dat['INTEG']
+        minus_19_esec =  rec_esec * scale_factor
+        new_rec = [pix_id, rec_esec, minus_19_esec, m.scale.val, dc / ref_dc]
         for t_ccd in other_t_ccd:
             dc_temp = dark_scale_model((m.scale.val, m.dark_t_ref.val), t_ccd)
             new_rec.append(dc_temp / ref_dc)
         mini_table.append(new_rec)
     if not len(mini_table):
         return
-    colnames = ['PixId', 'Val', 'Val(-19)', 'Scale', 'r({:.1f})'.format(last_dat['TEMPCD'])]
+    colnames = ['PixId', 'e-/sec', 'e-/sec(-19)', 'Scale', 'r({:.1f})'.format(last_dat['TEMPCD'])]
     for t_ccd in other_t_ccd:
         colnames.append("r({})".format(t_ccd))
     mini_table = Table(rows=mini_table,
                        names=colnames)
-    mini_table['Val(-19)'].format = '.2f'
+    mini_table['e-/sec'].format = '.2f'
+    mini_table['e-/sec(-19)'].format = '.2f'
     mini_table['Scale'].format = '.4f'
     for col in mini_table.colnames:
         if col.startswith('r('):


### PR DESCRIPTION
The peak dark current in e-/sec that I expect for the warmest pixels in the simulation data should be around 150 to 200:

```
In [22]: np.sort(pixels * 0.7)  # dark current in e-/sec at about -19 C
         ....
         81.19999695,   90.29999542,   90.29999542,   92.40000153,
         93.79999542,   99.40000153,  123.19999695,  128.09999084,
        137.8999939 ,  143.5       ,  143.5       ,  144.8999939 ,
        157.5       ,  161.69999695,  193.8999939 ,  213.5       ], dtype=float3
```

However, the fit values `value(-19)` are nowhere near that:

```
*************************************************
Time = 2015:251:22:12:53.006
CCD temperature = -14.99
Slot = 6.0

Fit values:

PixId Val Val(-19) Scale  r(-15.0) r(-10) r(-5) r(0)  r(5) r(10)
----- --- -------- ------ -------- ------ ----- ---- ----- -----
r1_c1 1.0     0.68 0.6803     1.47   2.38  3.85 6.23 10.09 16.33
r1_c4 3.0     2.05 0.6843     1.46   2.35  3.77 6.06  9.74 15.65
r3_c6 1.0     0.67 0.6737     1.49   2.43  3.98 6.53 10.69 17.52
r4_c3 3.0     2.07 0.6896     1.45   2.31  3.67 5.84  9.30 14.80
r4_c4 5.0     3.44 0.6891     1.45   2.31  3.68 5.86  9.34 14.87
r5_c3 6.0     4.16 0.6940     1.44   2.27  3.59 5.67  8.95 14.13
r5_c4 4.0     2.76 0.6907     1.45   2.30  3.65 5.80  9.21 14.62
r5_c5 2.0     1.37 0.6878     1.46   2.32  3.71 5.92  9.45 15.08
r7_c2 3.0     2.07 0.6916     1.45   2.29  3.64 5.76  9.14 14.49
*************************************************
```

What's happening?
